### PR TITLE
Try to produce an output for linux without openmp usage.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ "$openmp_impl" == "libgomp" || "$openmp_impl" == "llvm-openmp" || "$openmp_impl" == "intel-openmp" ]]; then
+    SLEEF_ENABLE_OPENMP=ON
+else
+    SLEEF_ENABLE_OPENMP=OFF
+fi
+
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
   (
     mkdir -p native-build
@@ -28,6 +34,7 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
       -DSLEEF_BUILD_TESTS=OFF \
       -DSLEEF_ENABLE_TESTER4=OFF \
       -DSLEEF_ENABLE_TLFLOAT=OFF \
+      -DSLEEF_ENABLE_OPENMP=${SLEEF_ENABLE_OPENMP} \
       ..
     ninja -j${CPU_COUNT}
   )
@@ -60,6 +67,7 @@ cmake ${CMAKE_ARGS} \
     -DSLEEF_BUILD_TESTS=OFF \
     -DSLEEF_ENABLE_TESTER4=OFF \
     -DSLEEF_ENABLE_TLFLOAT=OFF \
+    -DSLEEF_ENABLE_OPENMP=${SLEEF_ENABLE_OPENMP} \
     ..
 
 cmake --build . --target install

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+openmp_impl:
+  - no-openmp
+  - libgomp  #[linux and blas_impl != "mkl"]
+  - llvm-openmp  #[osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  string: {{ openmp_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  string: {{ openmp_impl | replace("-", "_") }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     # SO name changes at minor rev bumps.
     - {{ pin_subpackage('sleef', max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: af60856abac08a3b5e72a8d156dd71fec1f7ac23de8ee67793f45f9edcdf0908
 
 build:
-  number: 0
+  number: 1
+  string: {{ openmp_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     # SO name changes at minor rev bumps.
     - {{ pin_subpackage('sleef', max_pin='x') }}
@@ -25,11 +26,13 @@ requirements:
     - git
     - ninja-base  # [unix]
   host:
-    - libgomp 15.2.0 # [linux]
-    - llvm-openmp {{ cxx_compiler_version }}  # [osx]
+    - libgomp {{ cxx_compiler_version }}      # [openmp_impl == "libgomp"]
+    - intel-openmp                            # [openmp_impl == "intel-openmp"]
+    - llvm-openmp {{ cxx_compiler_version }}  # [openmp_impl == "llvm-openmp"]
   run:
-    - libgomp  # [linux]
-    - llvm-openmp  # [osx]
+    - libgomp      # [openmp_impl == "libgomp"]
+    - intel-openmp  # [openmp_impl == "intel-openmp"]
+    - llvm-openmp   # [openmp_impl == "llvm-openmp"]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - intel-openmp                            # [openmp_impl == "intel-openmp"]
     - llvm-openmp {{ cxx_compiler_version }}  # [openmp_impl == "llvm-openmp"]
   run:
-    - libgomp      # [openmp_impl == "libgomp"]
+    - libgomp       # [openmp_impl == "libgomp"]
     - intel-openmp  # [openmp_impl == "intel-openmp"]
     - llvm-openmp   # [openmp_impl == "llvm-openmp"]
 


### PR DESCRIPTION
Add a no_openmp output, so mkl builds of pytorch can still use sleef. 